### PR TITLE
fix(ci): update reusable workflow refs

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   quality:
-    uses: benvon/reusable-workflows/.github/workflows/go-quality.yml@130a938eed408977d8c3159327f13306f422b1eb
+    uses: benvon/reusable-workflows/.github/workflows/go-quality.yml@f70796de0a6527dbed267a64835c3cc81b8144e0
     with:
       quality_command: make ci-local
       coverage_file: coverage.out

--- a/.github/workflows/release-policy.yml
+++ b/.github/workflows/release-policy.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
   pull-requests: write
 
 jobs:

--- a/.github/workflows/release-policy.yml
+++ b/.github/workflows/release-policy.yml
@@ -10,6 +10,6 @@ permissions:
 
 jobs:
   release-policy:
-    uses: benvon/reusable-workflows/.github/workflows/release-policy.yml@130a938eed408977d8c3159327f13306f422b1eb
+    uses: benvon/reusable-workflows/.github/workflows/release-policy.yml@f70796de0a6527dbed267a64835c3cc81b8144e0
     with:
       pull_request_number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   release-tag:
-    uses: benvon/reusable-workflows/.github/workflows/release-tag.yml@130a938eed408977d8c3159327f13306f422b1eb
+    uses: benvon/reusable-workflows/.github/workflows/release-tag.yml@f70796de0a6527dbed267a64835c3cc81b8144e0
     with:
       caller_event_name: ${{ github.event_name }}
       caller_sha: ${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   release:
-    uses: benvon/reusable-workflows/.github/workflows/go-goreleaser-release.yml@130a938eed408977d8c3159327f13306f422b1eb
+    uses: benvon/reusable-workflows/.github/workflows/go-goreleaser-release.yml@f70796de0a6527dbed267a64835c3cc81b8144e0


### PR DESCRIPTION
## Summary
Bump all reusable workflow callers in this repo from 130a938eed408977d8c3159327f13306f422b1eb to f70796de0a6527dbed267a64835c3cc81b8144e0.

## Why
The newer reusable workflow revision includes the workflow permissions fix in release-policy. Updating all callers together keeps this repo from mixing old and new reusable workflow SHAs and avoids the failing Dependabot update path.

## Validation
- Verified the four workflow callers now point at f70796de0a6527dbed267a64835c3cc81b8144e0.
- Verified the git commit is signed.
- Updated the PR body after converting from draft to trigger the required release-policy check.